### PR TITLE
Constructing pin hierarchy: digital<-analog<-touch pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# microbitstubs
+# micro:bit stubs
 Stubs for all the methods and classes within the Micro:Bit module, so that intellisense can be used with them in Visual Studio Code
 
 Should make it more easy to teach Python programming with Visual Studio Code.

--- a/__init__.py
+++ b/__init__.py
@@ -91,7 +91,7 @@ class _MicroBitDigitalPin:
     def __init__(self):
         a = 0
 
-class _MicroBitAnalogDigitalPin:
+class _MicroBitAnalogDigitalPin(_MicroBitDigitalPin):
     """Analog (PWM) pin on the Micro:Bit board"""
 
     def read_analog(self):
@@ -116,7 +116,7 @@ class _MicroBitAnalogDigitalPin:
     def __init__(self):
         a = 0
 
-class _MicroBitTouchPin:
+class _MicroBitTouchPin(_MicroBitAnalogDigitalPin):
     """Touch sensitive pin on the Micro:Bit board"""
 
     def is_touched(self):

--- a/properly set out/__init__.py
+++ b/properly set out/__init__.py
@@ -41,7 +41,7 @@ class _MicroBitDigitalPin:
     def __init__(self):
         a = 0
 
-class _MicroBitAnalogDigitalPin:
+class _MicroBitAnalogDigitalPin(_MicroBitDigitalPin):
     """Analog (PWM) pin on the Micro:Bit board"""
 
     def read_analog(self):
@@ -66,7 +66,7 @@ class _MicroBitAnalogDigitalPin:
     def __init__(self):
         a = 0
 
-class _MicroBitTouchPin:
+class _MicroBitTouchPin(_MicroBitAnalogDigitalPin):
     """Touch sensitive pin on the Micro:Bit board"""
 
     def is_touched(self):


### PR DESCRIPTION
According to the MicroPython [documentation](https://microbit-micropython.readthedocs.io/en/v1.0.1/pin.html), classes of pins are constructed around a _hierarchy_ "so that each class has all the functionality of the previous class, and adds its own to that": digital <- analog <- touch. This allows, for instance, to see all the functionalities of pin0, which is a **touch** pin, but should also supports the functions of **digital** and **analog** pins.

The changes below implement the class inheritance necessary to construct the aforementioned hierarchy.